### PR TITLE
Deploy using Sphinx multiversion.

### DIFF
--- a/.github/workflows/spaceros.yml
+++ b/.github/workflows/spaceros.yml
@@ -47,7 +47,7 @@ jobs:
           pip install --no-warn-script-location --user --upgrade -r requirements.txt
 
       - name: Build
-        run: make html
+        run: make multiversion
 
       - name: Deploy to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@v4


### PR DESCRIPTION
The site currently deployed only covers rolling.

While this is nice from a tidyness perspective we shouldn't maintain it
because it would make it harder to switch to the multiversion setup
later since we would want to support redirects for the single-version
links.