### PR TITLE
Update title for doc site.

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -2,7 +2,7 @@
 
   Docs-Guide
 
-ROS 2 Documentation
+Space ROS Documentation
 ===================
 
 .. toctree::


### PR DESCRIPTION
There are several places where these docs still say ROS 2 rather than Space ROS but this is a big one.