### PR TITLE
Updated broken or non-existent links to a few doc pages

### DIFF
--- a/source/Demos/Canadarm.rst
+++ b/source/Demos/Canadarm.rst
@@ -1,7 +1,5 @@
 Canadarm Demo
 =============
 
-TODO:
+Instructions for running this demo can be found `here <https://github.com/space-ros/docker/tree/main/space_robots#canadarm-demo>`_ .
 
-Describe how to run the Canadarm demo.
-This may be simply a link to the demo repo that provides the instructions.

--- a/source/Demos/Mars-Rover.rst
+++ b/source/Demos/Mars-Rover.rst
@@ -1,7 +1,4 @@
 Mars Rover Demo
 ===============
 
-TODO:
-
-Describe how to run the Mars rover demo.
-This may be simply a link to the demo repo that provides the instructions
+Instructions for running this demo can be found `here <https://github.com/space-ros/docker/tree/main/space_robots#curiosity-mars-rover-demo>`_ .

--- a/source/Getting-Started/Docker-Images.rst
+++ b/source/Getting-Started/Docker-Images.rst
@@ -1,9 +1,35 @@
 The Space ROS Docker Images
 ===========================
 
-TODO:
+There are a few Space ROS Docker images you could use for your application, such as:
 
-Describe how to use the Space ROS docker image from Docker Hub, and any other images published to Docker Hub.
+* **space-ros:** This is the base SpaceROS image.
+* **moveit2:**  This image uses ``space-ros`` as base image and then pulls and builds the latest MoveIt2 source code.
+* **space_robots:** This image uses ``space-ros`` as base image and then installs the demonstration source code necessary to run the Canadarm and Mars Rover demos.
 
-* Docker Hub
-* Base image, MoveIt2, demos, etc.
+For a complete list of additional docker images, please refer to the `space-ros/docker repository <https://github.com/space-ros/docker/blob/main>`_ .
+
+space-ros image
+---------------
+
+The ``space-ros`` image can be accessed in two ways:
+
+* **Docker Hub**
+
+  You can pull the space-ros image from `DockerHub <https://hub.docker.com/r/osrf/space-ros>`_ :
+
+  .. code-block:: bash
+
+     $ docker pull osrf/space-ros
+
+* **Build image locally**
+
+  Follow the steps in the `USAGE.md <https://github.com/space-ros/space-ros/blob/main/docs/USAGE.md>`_ file from the ``space-ros`` repository.
+
+
+space-robots image
+-------------------
+
+If you want to test the robot demos, you'll need to build these images. Instructions for doing this are available in the space_robots  `README <https://github.com/space-ros/docker/blob/main/space_robots/README.md>`_
+
+

--- a/source/Introduction/How-Space-ROS-Differs.rst
+++ b/source/Introduction/How-Space-ROS-Differs.rst
@@ -111,6 +111,6 @@ The Space ROS project also incorporates space-specific functionality, such as a 
      - `RTEMS <https://www.rtems.org/>`_ is an open source real-time operating system that supports open standard application programming interfaces such as POSIX and is used in space flight, medical, networking and many more embedded devices.
        To further support flight software systems we build Space ROS for RTEMS and have a demonstration application that runs on RTEMS.
    * - cFS/ROS 2 Bridge
-     - There is an active project, the `BRASH Integration Toolkit for ROS2 and Flight Software Interoperability	<https://sbir.nasa.gov/SBIR/abstracts/20/sttr/phase2/STTR-20-2-T4.01-5037.html>`_, that promises to bridge the gap between Space ROS and legacy flight software systems.
+     - There is an active project, the `BRASH Integration Toolkit for ROS2 and Flight Software Interoperability	<https://traclabs-brash.bitbucket.io>`_, that promises to bridge the gap between Space ROS and legacy flight software systems.
        We hope to work with this project to integrate some of the core functionality into Space ROS.
 


### PR DESCRIPTION
Specifically, added some minimal content (mostly links to the relevant pages) to the following sections:

1. Docker Image: Links to tie DockerHub and README from the space-ros/docker repo.
2. Canadarm & Mars: Added a line at each page with links to the space_robots's README's relevant sections.
3. How-SpaceROS-Differs: Updated a broken link to the BRASH ROS2/cFS bridge documentation page.

This PR is related to this issue: https://github.com/space-ros/docs/issues/29 insofar that it fixes some broken links.

PS.- (I originally was intending to work on a different issue on the space-ros board - one regarding adding a test for the mars rover - but ended up adding these docs updates as I was trying to build the space-robots image).